### PR TITLE
Return undefined in resource bundle if pluginBundle doesn't exist

### DIFF
--- a/sketch-specifics.js
+++ b/sketch-specifics.js
@@ -19,7 +19,7 @@ module.exports.cwd = function cwd() {
 }
 
 module.exports.resourcePath = function resourcePath(resourceName) {
-  if (typeof __command === 'undefined' || __command.pluginBundle()) {
+  if (typeof __command === 'undefined' || !__command.pluginBundle()) {
     return undefined
   }
   var resource = __command.pluginBundle().urlForResourceNamed(resourceName)


### PR DESCRIPTION
There's a boolean typo in `sketch-specifics.js` which means `resourcePath()` always fails by returning undefined. This PR fixes that

Currently:
```javascript
  if (typeof __command === 'undefined' || __command.pluginBundle()) {
    return undefined
  }
```

Here, `__command.pluginBundle()` will be truthy in situations where we want to use it later on. So the function will return `undefined` incorrectly — we can flip that boolean to be `!__command.pluginBundle()`, and the function will correctly fail.